### PR TITLE
Fix setup.py for modern setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,11 @@ from __future__ import unicode_literals
 import io
 from os import path
 
-from pip.req import parse_requirements
+try:
+    from pip.req import parse_requirements
+except ImportError:
+    from pip._internal.req import parse_requirements
+
 from setuptools import find_packages, setup
 
 
@@ -22,12 +26,13 @@ def get_requirements(requirements_file):
     requirements = []
     if path.isfile(requirements_file):
         for req in parse_requirements(requirements_file, session="hack"):
-            # check markers, such as
-            #
-            #     rope_py3k    ; python_version >= '3.0'
-            #
-            if req.match_markers():
-                requirements.append(str(req.req))
+            try:
+                if req.markers:
+                    requirements.append("%s;%s" % (req.req, req.markers))
+                else:
+                    requirements.append("%s" % req.req)
+            except AttributeError:
+                requirements.append(req.requirement)
     return requirements
 
 


### PR DESCRIPTION
Updates `setup.py` to make it compatible with recent-ish changes to setuptools - uses the same fix that was applied to `modoboa-dmarc` and should be sufficient until a proper update for non-deprecated setup routines is added.